### PR TITLE
Sentry連携のエラーハンドリング追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "effect": "^3.15.4",
     "inversify": "^7.5.1",
     "node-fetch": "^3.3.2",
-    "reflect-metadata": "^0.2.2"
+    "reflect-metadata": "^0.2.2",
+    "@sentry/node": "^7.110.0"
   }
 }

--- a/src/application/ErrorNotifier.mock.ts
+++ b/src/application/ErrorNotifier.mock.ts
@@ -1,0 +1,12 @@
+import { Effect } from "effect";
+import type { ErrorNotifier } from "./ErrorNotifier.js";
+
+export class MockErrorNotifier implements ErrorNotifier {
+  public readonly errors: unknown[] = [];
+
+  notify(err: unknown): Effect.Effect<void, Error> {
+    return Effect.sync(() => {
+      this.errors.push(err);
+    });
+  }
+}

--- a/src/application/ErrorNotifier.ts
+++ b/src/application/ErrorNotifier.ts
@@ -1,0 +1,5 @@
+import type { Effect } from "effect";
+
+export interface ErrorNotifier {
+  notify(err: unknown): Effect.Effect<void, Error>;
+}

--- a/src/config/Container.ts
+++ b/src/config/Container.ts
@@ -7,6 +7,8 @@ import { SlackCommandAdapter } from "../infrastructure/command/SlackCommandAdapt
 import { envConfig } from "./EnvConfig.js";
 import { TYPES } from "./Types.js";
 import { GA4PVCollector } from "../application/GA4PVCollector.js";
+import type { ErrorNotifier } from "../application/ErrorNotifier.js";
+import { SentryErrorNotifier } from "../infrastructure/error/SentryErrorNotifier.js";
 
 const container = new Container();
 
@@ -18,6 +20,10 @@ container
   .bind<string>(TYPES.config.SlackWebhookUrl)
   .toConstantValue(envConfig.SlackWebhookUrl);
 
+container
+  .bind<string>(TYPES.config.SentryDsn)
+  .toConstantValue(envConfig.SentryDsn);
+
 container.bind<PVQuery>(TYPES.PVQuery).to(Ga4PVQueryAdapter).inSingletonScope();
 
 container
@@ -28,6 +34,11 @@ container
 container
   .bind<GA4PVCollector>(TYPES.GA4PVCollector)
   .to(GA4PVCollector)
+  .inSingletonScope();
+
+container
+  .bind<ErrorNotifier>(TYPES.ErrorNotifier)
+  .to(SentryErrorNotifier)
   .inSingletonScope();
 
 export { container };

--- a/src/config/EnvConfig.ts
+++ b/src/config/EnvConfig.ts
@@ -14,4 +14,5 @@ const c = new EnvConfig(process.env);
 export const envConfig = {
   GoogleKeyFilePath: c.get("GA_KEYFILE"),
   SlackWebhookUrl: c.get("SLACK_WEBHOOK"),
+  SentryDsn: c.get("SENTRY_DSN"),
 };

--- a/src/config/Types.ts
+++ b/src/config/Types.ts
@@ -2,8 +2,10 @@ export const TYPES = {
   config: {
     GoogleKeyFilePath: Symbol.for("GoogleKeyFilePath"),
     SlackWebhookUrl: Symbol.for("SlackWebhookUrl"),
+    SentryDsn: Symbol.for("SentryDsn"),
   },
   PVQuery: Symbol.for("PQuery"),
   SlackCommand: Symbol.for("SlackCommand"),
   GA4PVCollector: Symbol.for("GA4PVCollector"),
+  ErrorNotifier: Symbol.for("ErrorNotifier"),
 };

--- a/src/infrastructure/error/SentryErrorNotifier.ts
+++ b/src/infrastructure/error/SentryErrorNotifier.ts
@@ -1,0 +1,21 @@
+import { Effect } from "effect";
+import { inject, injectable } from "inversify";
+import * as Sentry from "@sentry/node";
+import type { ErrorNotifier } from "../../application/ErrorNotifier.js";
+import { TYPES } from "../../config/Types.js";
+
+@injectable()
+export class SentryErrorNotifier implements ErrorNotifier {
+  constructor(@inject(TYPES.config.SentryDsn) dsn: string) {
+    Sentry.init({ dsn });
+  }
+
+  notify(err: unknown): Effect.Effect<void, Error> {
+    return Effect.try({
+      try: () => {
+        Sentry.captureException(err);
+      },
+      catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+    });
+  }
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { Effect } from "effect";
+
+import { MockErrorNotifier } from "./application/ErrorNotifier.mock.js";
+
+vi.mock("@sentry/node", () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+}));
+class FailingCollector {
+  collectAndNotifyPV(): Effect.Effect<void, Error> {
+    return Effect.fail(new Error("fail"));
+  }
+}
+
+describe("main", () => {
+  it("calls ErrorNotifier on failure", async () => {
+    process.env.GA_KEYFILE = "dummy";
+    process.env.SLACK_WEBHOOK = "dummy";
+    process.env.SENTRY_DSN = "dummy";
+    const { container } = await import("./config/Container.js");
+    const { TYPES } = await import("./config/Types.js");
+
+    const mockNotifier = new MockErrorNotifier();
+    container.unbind(TYPES.GA4PVCollector);
+    container
+      .bind(TYPES.GA4PVCollector)
+      .toConstantValue(new FailingCollector() as any);
+    container.unbind(TYPES.ErrorNotifier);
+    container.bind(TYPES.ErrorNotifier).toConstantValue(mockNotifier);
+    process.env.GA_PROPERTIES = "A";
+    const exitMock = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => void 0);
+
+    await import("./main.js");
+    await Promise.resolve();
+
+    expect(mockNotifier.errors.length).toBe(1);
+
+    exitMock.mockRestore();
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Config, Effect, pipe } from "effect";
 import { GA4PVCollector } from "./application/GA4PVCollector.js";
+import type { ErrorNotifier } from "./application/ErrorNotifier.js";
 import { TYPES } from "./config/Types.js";
 import { container } from "./config/Container.js";
 
@@ -10,7 +11,7 @@ function propeties(): Config.Config<string[]> {
   );
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const collector = container.get<GA4PVCollector>(TYPES.GA4PVCollector);
   await pipe(
     propeties(),
@@ -19,4 +20,8 @@ async function main(): Promise<void> {
   );
 }
 
-main();
+main().catch(async (err) => {
+  const notifier = container.get<ErrorNotifier>(TYPES.ErrorNotifier);
+  await Effect.runPromise(notifier.notify(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要
- エラーハンドリング用インターフェース `ErrorNotifier` を追加
- Sentry を利用した `SentryErrorNotifier` を実装し、DI コンテナへ登録
- 環境変数 `SENTRY_DSN` を読み込むよう `EnvConfig` を更新
- `Types` と `Container` に新しい依存を追加
- `main` 実行時にエラーが発生した場合、`ErrorNotifier` で通知して終了
- 上記を検証するテストを追加

## テスト結果
- `pnpm test --run` を実行し、全テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_6840e210a0208332851aeb070b64248a