### PR TITLE
GitHub Actions: スケジュール実行に失敗通知を追加

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,35 @@
+name: Daily Run
+
+on:
+  schedule:
+    - cron: '0 21 * * *'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl -fsSL https://get.pnpm.io/install.sh | bash -
+      - run: echo '/home/runner/.local/share/pnpm:$PATH' >> $GITHUB_PATH
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+      - name: Install dependencies
+        run: make install
+      - name: Run Application
+        run: make run
+        env:
+          GA_KEYFILE: ${{ secrets.GA_KEYFILE }}
+          GA_PROPERTIES: ${{ secrets.GA_PROPERTIES }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      - name: Notify failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"Daily run failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' \
+            "$SLACK_WEBHOOK"
+


### PR DESCRIPTION
## 概要
- 毎日6時(JST)に `make run` を実行するワークフローに、失敗時にSlackへ通知するステップを追加しました
- UTCでは前日の21時に実行されます

## 必要な環境変数
- `GA_KEYFILE`
- `GA_PROPERTIES`
- `SLACK_WEBHOOK`
- `SENTRY_DSN`

これらはGitHubリポジトリのSecretsに登録してください。

**Labels:** AI_Codex

------
https://chatgpt.com/codex/tasks/task_e_6843a015e1048332b44a7267c97b477c