### PR TITLE
base64 decode修正

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
       - run: make install
-      - run: base64 --decode -i ${{ secrets.SERVICE_ACCOUNT_KEY_BASE64_TEXT }} > ServiceAccountKey.json
+      - run: echo "${{ secrets.SERVICE_ACCOUNT_KEY_BASE64_TEXT }}" | base64 --decode > ServiceAccountKey.json
       - run: make run
         env:
           GA_KEYFILE: ServiceAccountKey.json


### PR DESCRIPTION
## 概要
GitHub ActionsでSERVICE_ACCOUNT_KEY_BASE64_TEXTをデコードする処理が文字列として扱われておらず、`base64`コマンドが失敗していました。`echo`で文字列を渡してデコードするよう修正しました。

## 変更内容
- `.github/workflows/schedule.yml` のデコード処理を修正

## テスト
- `make install`
- `make lint`
- `make tsc`
- `make test`

以上がすべて成功することを確認しました。


------
https://chatgpt.com/codex/tasks/task_e_6844e6e36b448332a495516614ab86b8