### PR TITLE
スケジュールワークフロー手動実行化

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -3,6 +3,7 @@ name: Daily Run
 on:
   schedule:
     - cron: "0 21 * * *"
+  workflow_dispatch:
 
 jobs:
   run:


### PR DESCRIPTION
## 変更内容
- GitHub Actions の `schedule.yml` に `workflow_dispatch` を追加し、スケジュール実行ワークフローを手動でも起動できるようにしました。

## テスト結果
- `make lint/fix`
- `make test`

## ラベル
AI_Codex

------
https://chatgpt.com/codex/tasks/task_e_6844e8f166808332bd52004fa82222da